### PR TITLE
Added further configuration/permissions granularity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.github.ProtocolSupport</groupId>
       <artifactId>ProtocolSupport</artifactId>
-      <version>master-66b494a8dd-1</version>
+      <version>66b494a8dd</version>
       <scope>provided</scope>
     </dependency>
     <!--  Prism -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,20 +81,20 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.13.2-R0.1-SNAPSHOT</version>
+      <version>1.8-R0.1-SNAPSHOT</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>us.myles</groupId>
       <artifactId>viaversion</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.ProtocolSupport</groupId>
       <artifactId>ProtocolSupport</artifactId>
-      <version>master-SNAPSHOT</version>
+      <version>master-66b494a8dd-1</version>
       <scope>provided</scope>
     </dependency>
     <!--  Prism -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.8-R0.1-SNAPSHOT</version>
+      <version>1.13.2-R0.1-SNAPSHOT</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/src/main/java/com/bobcat00/viaversionstatus/Config.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Config.java
@@ -122,7 +122,7 @@ public class Config
 
         if (!contains("warn-players-newer", true))
         {
-            plugin.getConfig().set("warn-players-newer", false);
+            plugin.getConfig().set("warn-players-newer", true);
         }
 
         if (!contains("warn-string-newer", true))

--- a/src/main/java/com/bobcat00/viaversionstatus/Config.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Config.java
@@ -47,19 +47,34 @@ public class Config
     
     // Warning for players with mismatched version
     
-    public boolean getWarnPlayers()
+    public boolean getOlderVersionWarnPlayers()
     {
         return plugin.getConfig().getBoolean("warn-players");
     }
     
-    public String getWarnString()
+    public String getOlderVersionWarnString()
     {
         return plugin.getConfig().getString("warn-string");
     }
     
-    public String getWarnCommand()
+    public String getOlderVersionWarnCommand()
     {
         return plugin.getConfig().getString("warn-command");
+    }
+
+    public boolean getNewerVersionWarnPlayers()
+    {
+        return plugin.getConfig().getBoolean("warn-players-newer");
+    }
+
+    public String getNewerVersionWarnString()
+    {
+        return plugin.getConfig().getString("warn-string-newer");
+    }
+
+    public String getNewerVersionWarnCommand()
+    {
+        return plugin.getConfig().getString("warn-command-newer");
     }
     
     // Listener priority
@@ -104,6 +119,21 @@ public class Config
         {
             plugin.getConfig().set("warn-command", "");
         }
+
+        if (!contains("warn-players-newer", true))
+        {
+            plugin.getConfig().set("warn-players-newer", false);
+        }
+
+        if (!contains("warn-string-newer", true))
+        {
+            plugin.getConfig().set("warn-string-newer", "&cNOTICE: You are running Minecraft version &e%version%\n&cThe recommended version for this server is &a%server%");
+        }
+
+        if (!contains("warn-command-newer", true))
+        {
+            plugin.getConfig().set("warn-command-newer", "");
+        }
         
         if (!contains("list-supported-protocols", true))
         {
@@ -142,10 +172,16 @@ public class Config
             writer.write("notify-command: \"" + plugin.getConfig().getString("notify-command") + "\"" + "\n");
             writer.write("\n");
             
-            writer.write("# Warn players when they have a mismatched version" + "\n");
+            writer.write("# Warn players when they are using an older version" + "\n");
             writer.write("warn-players: " + plugin.getConfig().getBoolean("warn-players") + "\n");
             writer.write("warn-string: \"" + plugin.getConfig().getString("warn-string").replaceAll("\n", "\\\\n") + "\"" + "\n");
             writer.write("warn-command: \"" + plugin.getConfig().getString("warn-command") + "\"" + "\n");
+            writer.write("\n");
+
+            writer.write("# Warn players when they are using a newer version" + "\n");
+            writer.write("warn-players-newer: " + plugin.getConfig().getBoolean("warn-players-newer") + "\n");
+            writer.write("warn-string-newer: \"" + plugin.getConfig().getString("warn-string-newer").replaceAll("\n", "\\\\n") + "\"" + "\n");
+            writer.write("warn-command-newer: \"" + plugin.getConfig().getString("warn-command-newer") + "\"" + "\n");
             writer.write("\n");
             
             writer.write("# Run at the highest priority (MONITOR)" + "\n");

--- a/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
@@ -229,14 +229,17 @@ public final class Listeners implements Listener
         {
             plugin.getLogger().info(player.getName() + " is using version " + clientProtocol.toString() + ".");
         }
-        
-        // 2. Notify ops
-        
+
+        // 2. Notify any player with the `viaversionstatus.notify` permission (ops by default)
+
         if (!player.hasPermission("viaversionstatus.exempt.notify"))
         {
-            if (!player.hasPermission("viaversionstatus.exempt.notify.message")) {
-                for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-                    if (p.hasPermission("viaversionstatus.notify")) {
+            if (!player.hasPermission("viaversionstatus.exempt.notify.message"))
+            {
+                for (Player p : Bukkit.getServer().getOnlinePlayers())
+                {
+                    if (p.hasPermission("viaversionstatus.notify"))
+                    {
                         p.sendMessage(ChatColor.translateAlternateColorCodes('&',
                                 plugin.config.getNotifyString().replace("%player%", player.getName()).
                                                                 replace("%displayname%", player.getDisplayName()).
@@ -246,17 +249,22 @@ public final class Listeners implements Listener
                 }
             }
 
-            if (!player.hasPermission("viaversionstatus.exempt.notify.command")) {
+            if (!player.hasPermission("viaversionstatus.exempt.notify.command"))
+            {
                 String notifyCommand = plugin.config.getNotifyCommand();
-                if (!notifyCommand.isEmpty()) {
+                if (!notifyCommand.isEmpty())
+                {
                     notifyCommand = notifyCommand.replace("%player%", player.getName()).
                                                   replace("%displayname%", player.getDisplayName()).
                                                   replace("%version%", clientVersion).
                                                   replace("%server%", serverVersion);
                     plugin.getLogger().info("Executing command " + notifyCommand);
-                    try {
+                    try
+                    {
                         Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), notifyCommand);
-                    } catch (CommandException exc) {
+                    }
+                    catch (CommandException exc)
+                    {
                         plugin.getLogger().info("Command returned exception: " + exc.getMessage());
                     }
                 }
@@ -270,12 +278,16 @@ public final class Listeners implements Listener
             (clientProtocol.getId() < serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn"))
         {
-            if (!player.hasPermission("viaversionstatus.exempt.warn.message")) {
+            if (!player.hasPermission("viaversionstatus.exempt.warn.message"))
+            {
                 // Delay by 250 msec (5 ticks) to make sure the player sees the message
-                Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+                Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
+                {
                     @Override
-                    public void run() {
-                        if (player.isOnline()) {
+                    public void run()
+                    {
+                        if (player.isOnline())
+                        {
                             player.sendMessage(ChatColor.translateAlternateColorCodes('&',
                                     plugin.config.getOlderVersionWarnString().replace("%player%", player.getName()).
                                                                               replace("%displayname%", player.getDisplayName()).
@@ -286,17 +298,22 @@ public final class Listeners implements Listener
                 }, 5L); // time delay (ticks)
             }
 
-            if (!player.hasPermission("viaversionstatus.exempt.warn.command")) {
+            if (!player.hasPermission("viaversionstatus.exempt.warn.command"))
+            {
                 String warnCommand = plugin.config.getOlderVersionWarnCommand();
-                if (!warnCommand.isEmpty()) {
+                if (!warnCommand.isEmpty())
+                {
                     warnCommand = warnCommand.replace("%player%", player.getName()).
                                               replace("%displayname%", player.getDisplayName()).
                                               replace("%version%", clientVersion).
                                               replace("%server%", serverVersion);
                     plugin.getLogger().info("Executing command " + warnCommand);
-                    try {
+                    try
+                    {
                         Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), warnCommand);
-                    } catch (CommandException exc) {
+                    }
+                    catch (CommandException exc)
+                    {
                         plugin.getLogger().info("Command returned exception: " + exc.getMessage());
                     }
                 }
@@ -310,12 +327,16 @@ public final class Listeners implements Listener
             (clientProtocol.getId() > serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn.newer"))
         {
-            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.message")) {
+            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.message"))
+            {
                 // Delay by 250 msec (5 ticks) to make sure the player sees the message
-                Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+                Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
+                {
                     @Override
-                    public void run() {
-                        if (player.isOnline()) {
+                    public void run()
+                    {
+                        if (player.isOnline())
+                        {
                             player.sendMessage(ChatColor.translateAlternateColorCodes('&',
                                     plugin.config.getNewerVersionWarnString().replace("%player%", player.getName()).
                                                                               replace("%displayname%", player.getDisplayName()).
@@ -326,17 +347,22 @@ public final class Listeners implements Listener
                 }, 5L); // time delay (ticks)
             }
 
-            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.command")) {
+            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.command"))
+            {
                 String newerVersionWarnCommand = plugin.config.getNewerVersionWarnCommand();
-                if (!newerVersionWarnCommand.isEmpty()) {
+                if (!newerVersionWarnCommand.isEmpty())
+                {
                     newerVersionWarnCommand = newerVersionWarnCommand.replace("%player%", player.getName()).
                                                                       replace("%displayname%", player.getDisplayName()).
                                                                       replace("%version%", clientVersion).
                                                                       replace("%server%", serverVersion);
                     plugin.getLogger().info("Executing command " + newerVersionWarnCommand);
-                    try {
+                    try
+                    {
                         Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), newerVersionWarnCommand);
-                    } catch (CommandException exc) {
+                    }
+                    catch (CommandException exc)
+                    {
                         plugin.getLogger().info("Command returned exception: " + exc.getMessage());
                     }
                 }

--- a/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
@@ -241,10 +241,10 @@ public final class Listeners implements Listener
                     if (p.hasPermission("viaversionstatus.notify"))
                     {
                         p.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                                plugin.config.getNotifyString().replace("%player%", player.getName()).
-                                                                replace("%displayname%", player.getDisplayName()).
-                                                                replace("%version%", clientVersion).
-                                                                replace("%server%", serverVersion)));
+                            plugin.config.getNotifyString().replace("%player%", player.getName()).
+                                                            replace("%displayname%", player.getDisplayName()).
+                                                            replace("%version%", clientVersion).
+                                                            replace("%server%", serverVersion)));
                     }
                 }
             }
@@ -278,46 +278,7 @@ public final class Listeners implements Listener
             (clientProtocol.getId() < serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn"))
         {
-            if (!player.hasPermission("viaversionstatus.exempt.warn.message"))
-            {
-                // Delay by 250 msec (5 ticks) to make sure the player sees the message
-                Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
-                        if (player.isOnline())
-                        {
-                            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                                    plugin.config.getOlderVersionWarnString().replace("%player%", player.getName()).
-                                                                              replace("%displayname%", player.getDisplayName()).
-                                                                              replace("%version%", clientVersion).
-                                                                              replace("%server%", serverVersion)));
-                        }
-                    }
-                }, 5L); // time delay (ticks)
-            }
-
-            if (!player.hasPermission("viaversionstatus.exempt.warn.command"))
-            {
-                String warnCommand = plugin.config.getOlderVersionWarnCommand();
-                if (!warnCommand.isEmpty())
-                {
-                    warnCommand = warnCommand.replace("%player%", player.getName()).
-                                              replace("%displayname%", player.getDisplayName()).
-                                              replace("%version%", clientVersion).
-                                              replace("%server%", serverVersion);
-                    plugin.getLogger().info("Executing command " + warnCommand);
-                    try
-                    {
-                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), warnCommand);
-                    }
-                    catch (CommandException exc)
-                    {
-                        plugin.getLogger().info("Command returned exception: " + exc.getMessage());
-                    }
-                }
-            }
+            handleMismatchedClientServerVersionsForTargetPlayer(player, "viaversionstatus.exempt.warn.message", "viaversionstatus.exempt.warn.command", plugin.config.getOlderVersionWarnString(), plugin.config.getOlderVersionWarnCommand(), clientVersion, serverVersion);
         }
 
         // 4. Warn player if they are connecting using a newer version
@@ -327,46 +288,7 @@ public final class Listeners implements Listener
             (clientProtocol.getId() > serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn.newer"))
         {
-            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.message"))
-            {
-                // Delay by 250 msec (5 ticks) to make sure the player sees the message
-                Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
-                        if (player.isOnline())
-                        {
-                            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                                    plugin.config.getNewerVersionWarnString().replace("%player%", player.getName()).
-                                                                              replace("%displayname%", player.getDisplayName()).
-                                                                              replace("%version%", clientVersion).
-                                                                              replace("%server%", serverVersion)));
-                        }
-                    }
-                }, 5L); // time delay (ticks)
-            }
-
-            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.command"))
-            {
-                String newerVersionWarnCommand = plugin.config.getNewerVersionWarnCommand();
-                if (!newerVersionWarnCommand.isEmpty())
-                {
-                    newerVersionWarnCommand = newerVersionWarnCommand.replace("%player%", player.getName()).
-                                                                      replace("%displayname%", player.getDisplayName()).
-                                                                      replace("%version%", clientVersion).
-                                                                      replace("%server%", serverVersion);
-                    plugin.getLogger().info("Executing command " + newerVersionWarnCommand);
-                    try
-                    {
-                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), newerVersionWarnCommand);
-                    }
-                    catch (CommandException exc)
-                    {
-                        plugin.getLogger().info("Command returned exception: " + exc.getMessage());
-                    }
-                }
-            }
+            handleMismatchedClientServerVersionsForTargetPlayer(player, "viaversionstatus.exempt.warn.newer.message", "viaversionstatus.exempt.warn.newer.command", plugin.config.getNewerVersionWarnString(), plugin.config.getNewerVersionWarnCommand(), clientVersion, serverVersion);
         }
         
         // 5. Send to Prism
@@ -377,5 +299,47 @@ public final class Listeners implements Listener
         }
 
     }
-    
+
+    private void handleMismatchedClientServerVersionsForTargetPlayer(Player targetPlayer, String messagePermissionString, String commandPermissionString, String warnMessageFromPreferences, String warnCommandFromPreferences, String currentPlayerClientVersion, String currentServerVersion)
+    {
+        if (!targetPlayer.hasPermission(messagePermissionString))
+        {
+            // Delay by 250 msec (5 ticks) to make sure the player sees the message
+            Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    if (targetPlayer.isOnline())
+                    {
+                        targetPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                            warnMessageFromPreferences.replace("%player%", targetPlayer.getName()).
+                                                       replace("%displayname%", targetPlayer.getDisplayName()).
+                                                       replace("%version%", currentPlayerClientVersion).
+                                                       replace("%server%", currentServerVersion)));
+                    }
+                }
+            }, 5L); // time delay (ticks)
+        }
+
+        if (!targetPlayer.hasPermission(commandPermissionString))
+        {
+            if (!warnCommandFromPreferences.isEmpty())
+            {
+                warnCommandFromPreferences = warnCommandFromPreferences.replace("%player%", targetPlayer.getName()).
+                                                                        replace("%displayname%", targetPlayer.getDisplayName()).
+                                                                        replace("%version%", currentPlayerClientVersion).
+                                                                        replace("%server%", currentServerVersion);
+                plugin.getLogger().info("Executing command " + warnCommandFromPreferences);
+                try
+                {
+                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), warnCommandFromPreferences);
+                }
+                catch (CommandException exc)
+                {
+                    plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
@@ -305,7 +305,7 @@ public final class Listeners implements Listener
 
         // 4. Warn player if they are connecting using a newer version
 
-        if (plugin.config.getOlderVersionWarnPlayers() &&
+        if (plugin.config.getNewerVersionWarnPlayers() &&
             !serverVersion.equals("UNKNOWN") &&
             (clientProtocol.getId() > serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn.newer"))

--- a/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
@@ -241,10 +241,10 @@ public final class Listeners implements Listener
                     if (p.hasPermission("viaversionstatus.notify"))
                     {
                         p.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            plugin.config.getNotifyString().replace("%player%", player.getName()).
+                            plugin.config.getNotifyString().replace("%player%",      player.getName()).
                                                             replace("%displayname%", player.getDisplayName()).
-                                                            replace("%version%", clientVersion).
-                                                            replace("%server%", serverVersion)));
+                                                            replace("%version%",     clientVersion).
+                                                            replace("%server%",      serverVersion)));
                     }
                 }
             }
@@ -254,10 +254,10 @@ public final class Listeners implements Listener
                 String notifyCommand = plugin.config.getNotifyCommand();
                 if (!notifyCommand.isEmpty())
                 {
-                    notifyCommand = notifyCommand.replace("%player%", player.getName()).
+                    notifyCommand = notifyCommand.replace("%player%",      player.getName()).
                                                   replace("%displayname%", player.getDisplayName()).
-                                                  replace("%version%", clientVersion).
-                                                  replace("%server%", serverVersion);
+                                                  replace("%version%",     clientVersion).
+                                                  replace("%server%",      serverVersion);
                     plugin.getLogger().info("Executing command " + notifyCommand);
                     try
                     {
@@ -313,10 +313,10 @@ public final class Listeners implements Listener
                     if (targetPlayer.isOnline())
                     {
                         targetPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            warnMessageFromPreferences.replace("%player%", targetPlayer.getName()).
+                            warnMessageFromPreferences.replace("%player%",      targetPlayer.getName()).
                                                        replace("%displayname%", targetPlayer.getDisplayName()).
-                                                       replace("%version%", currentPlayerClientVersion).
-                                                       replace("%server%", currentServerVersion)));
+                                                       replace("%version%",     currentPlayerClientVersion).
+                                                       replace("%server%",      currentServerVersion)));
                     }
                 }
             }, 5L); // time delay (ticks)
@@ -326,10 +326,10 @@ public final class Listeners implements Listener
         {
             if (!warnCommandFromPreferences.isEmpty())
             {
-                warnCommandFromPreferences = warnCommandFromPreferences.replace("%player%", targetPlayer.getName()).
+                warnCommandFromPreferences = warnCommandFromPreferences.replace("%player%",      targetPlayer.getName()).
                                                                         replace("%displayname%", targetPlayer.getDisplayName()).
-                                                                        replace("%version%", currentPlayerClientVersion).
-                                                                        replace("%server%", currentServerVersion);
+                                                                        replace("%version%",     currentPlayerClientVersion).
+                                                                        replace("%server%",      currentServerVersion);
                 plugin.getLogger().info("Executing command " + warnCommandFromPreferences);
                 try
                 {

--- a/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/Listeners.java
@@ -234,33 +234,31 @@ public final class Listeners implements Listener
         
         if (!player.hasPermission("viaversionstatus.exempt.notify"))
         {
-            for (Player p: Bukkit.getServer().getOnlinePlayers())
-            {
-                if (p.hasPermission("viaversionstatus.notify"))
-                {
-                    p.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            plugin.config.getNotifyString().replace("%player%",      player.getName()).
-                            replace("%displayname%", player.getDisplayName()).
-                            replace("%version%",     clientVersion).
-                            replace("%server%",      serverVersion)));
+            if (!player.hasPermission("viaversionstatus.exempt.notify.message")) {
+                for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+                    if (p.hasPermission("viaversionstatus.notify")) {
+                        p.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                                plugin.config.getNotifyString().replace("%player%", player.getName()).
+                                                                replace("%displayname%", player.getDisplayName()).
+                                                                replace("%version%", clientVersion).
+                                                                replace("%server%", serverVersion)));
+                    }
                 }
             }
-            
-            String notifyCommand = plugin.config.getNotifyCommand();
-            if (!notifyCommand.isEmpty())
-            {
-                notifyCommand = notifyCommand.replace("%player%",      player.getName()).
-                        replace("%displayname%", player.getDisplayName()).
-                        replace("%version%",     clientVersion).
-                        replace("%server%",      serverVersion);
-                plugin.getLogger().info("Executing command " + notifyCommand);
-                try
-                {
-                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), notifyCommand);
-                }
-                catch (CommandException exc)
-                {
-                    plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+
+            if (!player.hasPermission("viaversionstatus.exempt.notify.command")) {
+                String notifyCommand = plugin.config.getNotifyCommand();
+                if (!notifyCommand.isEmpty()) {
+                    notifyCommand = notifyCommand.replace("%player%", player.getName()).
+                                                  replace("%displayname%", player.getDisplayName()).
+                                                  replace("%version%", clientVersion).
+                                                  replace("%server%", serverVersion);
+                    plugin.getLogger().info("Executing command " + notifyCommand);
+                    try {
+                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), notifyCommand);
+                    } catch (CommandException exc) {
+                        plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+                    }
                 }
             }
         }
@@ -272,38 +270,35 @@ public final class Listeners implements Listener
             (clientProtocol.getId() < serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn"))
         {
-            // Delay by 250 msec (5 ticks) to make sure the player sees the message
-            Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    if (player.isOnline())
-                    {
-                        player.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            plugin.config.getOlderVersionWarnString().replace("%player%",      player.getName()).
-                                                                      replace("%displayname%", player.getDisplayName()).
-                                                                      replace("%version%",     clientVersion).
-                                                                      replace("%server%",      serverVersion)));
+            if (!player.hasPermission("viaversionstatus.exempt.warn.message")) {
+                // Delay by 250 msec (5 ticks) to make sure the player sees the message
+                Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+                    @Override
+                    public void run() {
+                        if (player.isOnline()) {
+                            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                                    plugin.config.getOlderVersionWarnString().replace("%player%", player.getName()).
+                                                                              replace("%displayname%", player.getDisplayName()).
+                                                                              replace("%version%", clientVersion).
+                                                                              replace("%server%", serverVersion)));
+                        }
                     }
-                }
-            }, 5L); // time delay (ticks)
-            
-            String warnCommand = plugin.config.getOlderVersionWarnCommand();
-            if (!warnCommand.isEmpty())
-            {
-                warnCommand = warnCommand.replace("%player%",      player.getName()).
-                                          replace("%displayname%", player.getDisplayName()).
-                                          replace("%version%",     clientVersion).
-                                          replace("%server%",      serverVersion);
-                plugin.getLogger().info("Executing command " + warnCommand);
-                try
-                {
-                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), warnCommand);
-                }
-                catch (CommandException exc)
-                {
-                    plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+                }, 5L); // time delay (ticks)
+            }
+
+            if (!player.hasPermission("viaversionstatus.exempt.warn.command")) {
+                String warnCommand = plugin.config.getOlderVersionWarnCommand();
+                if (!warnCommand.isEmpty()) {
+                    warnCommand = warnCommand.replace("%player%", player.getName()).
+                                              replace("%displayname%", player.getDisplayName()).
+                                              replace("%version%", clientVersion).
+                                              replace("%server%", serverVersion);
+                    plugin.getLogger().info("Executing command " + warnCommand);
+                    try {
+                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), warnCommand);
+                    } catch (CommandException exc) {
+                        plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+                    }
                 }
             }
         }
@@ -315,38 +310,35 @@ public final class Listeners implements Listener
             (clientProtocol.getId() > serverProtocol.getId()) &&
             !player.hasPermission("viaversionstatus.exempt.warn.newer"))
         {
-            // Delay by 250 msec (5 ticks) to make sure the player sees the message
-            Bukkit.getScheduler().runTaskLater(plugin, new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    if (player.isOnline())
-                    {
-                        player.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            plugin.config.getNewerVersionWarnString().replace("%player%",      player.getName()).
-                                                                      replace("%displayname%", player.getDisplayName()).
-                                                                      replace("%version%",     clientVersion).
-                                                                      replace("%server%",      serverVersion)));
+            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.message")) {
+                // Delay by 250 msec (5 ticks) to make sure the player sees the message
+                Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+                    @Override
+                    public void run() {
+                        if (player.isOnline()) {
+                            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                                    plugin.config.getNewerVersionWarnString().replace("%player%", player.getName()).
+                                                                              replace("%displayname%", player.getDisplayName()).
+                                                                              replace("%version%", clientVersion).
+                                                                              replace("%server%", serverVersion)));
+                        }
                     }
-                }
-            }, 5L); // time delay (ticks)
+                }, 5L); // time delay (ticks)
+            }
 
-            String newerVersionWarnCommand = plugin.config.getNewerVersionWarnCommand();
-            if (!newerVersionWarnCommand.isEmpty())
-            {
-                newerVersionWarnCommand = newerVersionWarnCommand.replace("%player%",      player.getName()).
-                                          replace("%displayname%", player.getDisplayName()).
-                                          replace("%version%",     clientVersion).
-                                          replace("%server%",      serverVersion);
-                plugin.getLogger().info("Executing command " + newerVersionWarnCommand);
-                try
-                {
-                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), newerVersionWarnCommand);
-                }
-                catch (CommandException exc)
-                {
-                    plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+            if (!player.hasPermission("viaversionstatus.exempt.warn.newer.command")) {
+                String newerVersionWarnCommand = plugin.config.getNewerVersionWarnCommand();
+                if (!newerVersionWarnCommand.isEmpty()) {
+                    newerVersionWarnCommand = newerVersionWarnCommand.replace("%player%", player.getName()).
+                                                                      replace("%displayname%", player.getDisplayName()).
+                                                                      replace("%version%", clientVersion).
+                                                                      replace("%server%", serverVersion);
+                    plugin.getLogger().info("Executing command " + newerVersionWarnCommand);
+                    try {
+                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), newerVersionWarnCommand);
+                    } catch (CommandException exc) {
+                        plugin.getLogger().info("Command returned exception: " + exc.getMessage());
+                    }
                 }
             }
         }

--- a/src/main/java/com/bobcat00/viaversionstatus/ViaVersionStatus.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/ViaVersionStatus.java
@@ -111,13 +111,13 @@ public final class ViaVersionStatus extends JavaPlugin
         Metrics metrics = new Metrics(this, pluginId);
         
         metrics.addCustomChart(new SimplePie("connection_used",    () -> listeners.getConnectionUsed().toString()));
-        metrics.addCustomChart(new SimplePie("listener_priority",  () -> config.getHighPriority()                                        ? "Monitor" : "Normal"));
-        metrics.addCustomChart(new SimplePie("warn_players",       () -> config.getOlderVersionWarnPlayers()                             ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("warn_players_newer", () -> config.getNewerVersionWarnPlayers()                             ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("notify_command",     () -> !config.getNotifyCommand().isEmpty()                            ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("warn_command",       () -> !config.getOlderVersionWarnCommand().isEmpty()                  ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("warn_command_newer", () -> !config.getNewerVersionWarnCommand().isEmpty()                  ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("prism_integration",  () -> config.getPrismIntegration()                                    ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("listener_priority",  () -> config.getHighPriority()                                     ? "Monitor" : "Normal"));
+        metrics.addCustomChart(new SimplePie("warn_players",       () -> config.getOlderVersionWarnPlayers()                          ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_players_newer", () -> config.getNewerVersionWarnPlayers()                          ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("notify_command",     () -> !config.getNotifyCommand().isEmpty()                         ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_command",       () -> !config.getOlderVersionWarnCommand().isEmpty()               ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_command_newer", () -> !config.getNewerVersionWarnCommand().isEmpty()               ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("prism_integration",  () -> config.getPrismIntegration()                                 ? "Yes" : "No"));
         metrics.addCustomChart(new SimplePie("viaversion",         () -> Bukkit.getPluginManager().isPluginEnabled("ViaVersion")      ? "Yes" : "No"));
         metrics.addCustomChart(new SimplePie("viabackwards",       () -> Bukkit.getPluginManager().isPluginEnabled("ViaBackwards")    ? "Yes" : "No"));
         metrics.addCustomChart(new SimplePie("viarewind",          () -> Bukkit.getPluginManager().isPluginEnabled("ViaRewind")       ? "Yes" : "No"));

--- a/src/main/java/com/bobcat00/viaversionstatus/ViaVersionStatus.java
+++ b/src/main/java/com/bobcat00/viaversionstatus/ViaVersionStatus.java
@@ -110,16 +110,18 @@ public final class ViaVersionStatus extends JavaPlugin
         int pluginId = 4834;
         Metrics metrics = new Metrics(this, pluginId);
         
-        metrics.addCustomChart(new SimplePie("connection_used",   () -> listeners.getConnectionUsed().toString()));
-        metrics.addCustomChart(new SimplePie("listener_priority", () -> config.getHighPriority()                                     ? "Monitor" : "Normal"));
-        metrics.addCustomChart(new SimplePie("warn_players",      () -> config.getWarnPlayers()                                      ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("notify_command",    () -> !config.getNotifyCommand().isEmpty()                         ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("warn_command",      () -> !config.getWarnCommand().isEmpty()                           ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("prism_integration", () -> config.getPrismIntegration()                                 ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("viaversion",        () -> Bukkit.getPluginManager().isPluginEnabled("ViaVersion")      ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("viabackwards",      () -> Bukkit.getPluginManager().isPluginEnabled("ViaBackwards")    ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("viarewind",         () -> Bukkit.getPluginManager().isPluginEnabled("ViaRewind")       ? "Yes" : "No"));
-        metrics.addCustomChart(new SimplePie("protocolsupport",   () -> Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport") ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("connection_used",    () -> listeners.getConnectionUsed().toString()));
+        metrics.addCustomChart(new SimplePie("listener_priority",  () -> config.getHighPriority()                                        ? "Monitor" : "Normal"));
+        metrics.addCustomChart(new SimplePie("warn_players",       () -> config.getOlderVersionWarnPlayers()                             ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_players_newer", () -> config.getNewerVersionWarnPlayers()                             ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("notify_command",     () -> !config.getNotifyCommand().isEmpty()                            ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_command",       () -> !config.getOlderVersionWarnCommand().isEmpty()                  ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("warn_command_newer", () -> !config.getNewerVersionWarnCommand().isEmpty()                  ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("prism_integration",  () -> config.getPrismIntegration()                                    ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("viaversion",         () -> Bukkit.getPluginManager().isPluginEnabled("ViaVersion")      ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("viabackwards",       () -> Bukkit.getPluginManager().isPluginEnabled("ViaBackwards")    ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("viarewind",          () -> Bukkit.getPluginManager().isPluginEnabled("ViaRewind")       ? "Yes" : "No"));
+        metrics.addCustomChart(new SimplePie("protocolsupport",    () -> Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport") ? "Yes" : "No"));
         
         getLogger().info("You may opt-out of metrics by changing plugins/bStats/config.yml");
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,7 +12,7 @@ warn-string: "&cNOTICE: You are running Minecraft version &e%version%\n&cThe rec
 warn-command: ""
 
 # Warn players when they are using a newer version
-warn-players-newer: false
+warn-players-newer: true
 warn-string-newer: "&cNOTICE: You are running Minecraft version &e%version%\n&cThe recommended version for this server is &a%server%"
 warn-command-newer: ""
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,10 +6,15 @@
 notify-string: "&6Player &c%player% &6is using version &c%version%"
 notify-command: ""
 
-# Warn players when they have a mismatched version
+# Warn players when they are using an older version
 warn-players: true
 warn-string: "&cNOTICE: You are running Minecraft version &e%version%\n&cThe recommended version for this server is &a%server%"
 warn-command: ""
+
+# Warn players when they are using a newer version
+warn-players-newer: false
+warn-string-newer: "&cNOTICE: You are running Minecraft version &e%version%\n&cThe recommended version for this server is &a%server%"
+warn-command-newer: ""
 
 # Run at the highest priority (MONITOR)
 # Set to true if %displayname% doesn't work as expected

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,6 @@ name: ViaVersionStatus
 main: com.bobcat00.viaversionstatus.ViaVersionStatus
 version: ${project.version}
 author: Bobcat00
-api-version: 1.13
 softdepend: [ViaVersion, ProtocolSupport, ViaBackwards, ViaRewind, Prism]
 permissions:
   viaversionstatus.exempt.*:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ permissions:
       viaversionstatus.exempt.log: true
       viaversionstatus.exempt.notify: true
       viaversionstatus.exempt.warn: true
+      viaversionstatus.exempt.warn.newer: true
   viaversionstatus.exempt:
     description: Exempts this player from all processing at join
     default: false
@@ -21,8 +22,11 @@ permissions:
     description: Exempts this player from notifying other players at join
     default: false
   viaversionstatus.exempt.warn:
-    description: Exempts this player from receiving a mismatched version warning
+    description: Exempts this player from receiving an older version warning
+    default: false
+  viaversionstatus.exempt.warn.newer:
+    description: Exempts this player from receiving a newer version warning
     default: false
   viaversionstatus.notify:
-    description: Display other player client version at join
+    description: Displays other players' client versions at join
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: ViaVersionStatus
 main: com.bobcat00.viaversionstatus.ViaVersionStatus
 version: ${project.version}
 author: Bobcat00
+api-version: 1.13
 softdepend: [ViaVersion, ProtocolSupport, ViaBackwards, ViaRewind, Prism]
 permissions:
   viaversionstatus.exempt.*:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,5 +28,5 @@ permissions:
     description: Exempts this player from receiving a newer version warning
     default: false
   viaversionstatus.notify:
-    description: Displays other players' client versions at join
+    description: Allows this player to receive messages for other players' client versions at join
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,8 +10,14 @@ permissions:
       viaversionstatus.exempt: true
       viaversionstatus.exempt.log: true
       viaversionstatus.exempt.notify: true
+      viaversionstatus.exempt.notify.message: true
+      viaversionstatus.exempt.notify.command: true
       viaversionstatus.exempt.warn: true
+      viaversionstatus.exempt.warn.message: true
+      viaversionstatus.exempt.warn.command: true
       viaversionstatus.exempt.warn.newer: true
+      viaversionstatus.exempt.warn.newer.message: true
+      viaversionstatus.exempt.warn.newer.command: true
   viaversionstatus.exempt:
     description: Exempts this player from all processing at join
     default: false
@@ -19,13 +25,31 @@ permissions:
     description: Exempts this player from client version being logged at join
     default: false
   viaversionstatus.exempt.notify:
+    description: Exempts this player from notifying other players at join while also preventing them from triggering the configured join notification command
+    default: false
+  viaversionstatus.exempt.notify.message:
     description: Exempts this player from notifying other players at join
     default: false
+  viaversionstatus.exempt.notify.command:
+    description: Exempts this player from triggering the configured join notification command
+    default: false
   viaversionstatus.exempt.warn:
+    description: Exempts this player from receiving an older version warning while also preventing them from triggering the configured older version warning command
+    default: false
+  viaversionstatus.exempt.warn.message:
     description: Exempts this player from receiving an older version warning
     default: false
+  viaversionstatus.exempt.warn.command:
+    description: Exempts this player from triggering the configured older version warning command
+    default: false
   viaversionstatus.exempt.warn.newer:
+    description: Exempts this player from receiving an newer version warning while also preventing them from triggering the configured newer version warning command
+    default: false
+  viaversionstatus.exempt.warn.newer.message:
     description: Exempts this player from receiving a newer version warning
+    default: false
+  viaversionstatus.exempt.warn.newer.command:
+    description: Exempts this player from triggering the configured newer version warning command
     default: false
   viaversionstatus.notify:
     description: Allows this player to receive messages for other players' client versions at join


### PR DESCRIPTION
Added the ability to warn players and/or run a command *only if* they are connecting to a server using an older (or newer) version of Minecraft. This allows for higher configuration granularity for server administrators.

Further granularity has also been added to the permissions exemption system. It is now possible to exempt players from triggering _either_ the notification/older-version-warning/newer-version-warning command, message, or _both_.

Legacy behaviour is completely retained, so players with `viaversion.exempt.notify` or `viaversion.exempt.warn` set will experience identical behaviour to previous versions (it exempts them from both the message and the command trigger).

Some minor modifications were also done to `pom.xml` to fix a Maven dependency resolution failure that was causing builds to fail, and the Bukkit API target was lowered to 1.8 in order to avoid potential compatibility issues with Paper/Spigot/CraftBukkit 1.8.x.

---

### ViaVersionStatus now supports the following use-cases:
* Warning a player if their Minecraft client version is older than the server version (enabled by default)
	* Do not send the player an older version warning message _and_ do not trigger the configured older version warn command (`viaversion.exempt.warn`, identical behaviour as previous versions)
	* **Only** send the player a warning message _but do not_ trigger the configured newer version command (`viaversion.exempt.warn.command`)
	* **Only** trigger the configured older version warn command _but do not_ send the player a warning message (`viaversion.exempt.warn.message`)
* Warning a player if their Minecraft client version is newer than the server version (~~_disabled_ by default~~ enabled by default to maintain current behaviour)
	* Do not send the player a newer version warning message _and_ do not trigger the configured newer version command (`viaversion.exempt.warn.newer`)
	* **Only** send the player a warning message _but do not_ trigger the configured newer version command (`viaversion.exempt.warn.newer.command`)
	* **Only** trigger the configured newer version command _but do not_ send the player a warning message (`viaversion.exempt.warn.newer.message`)
* Warning a player if their Minecraft client version mismatches with the server version (simply enable both `warn-players` and `warn-players-newer` in the preferences file to achieve this)
* Exempting a player from having their client version sent to any player with the `viaversionstatus.notify` permission added _and_ triggering the configured notify command (`viaversion.exempt.notify`, same behaviour as previous versions)
	* Exempting a player _only from_ having their client version sent to any player with the `viaversionstatus.notify` permission added (`viaversion.exempt.notify.message`)
	* Exempting a player _only from_ triggering the configured notify command (`viaversion.exempt.notify.command`)